### PR TITLE
Update of required packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+.phpunit.cache
+

--- a/composer.json
+++ b/composer.json
@@ -4,20 +4,20 @@
     "license": "MIT",
     "require": {
         "php": ">=8.1",
-        "nette/utils": "^3.2",
-        "symfony/dependency-injection": "6.1.*"
+        "nette/utils": "^3.2 || ^4.0",
+        "symfony/dependency-injection": "^6.1"
     },
     "require-dev": {
         "php-parallel-lint/php-parallel-lint": "^1.3",
-        "phpstan/extension-installer": "^1.2",
-        "phpunit/phpunit": "^9.5.26",
-        "rector/rector": "^0.15.10",
-        "symplify/easy-ci": "^11.1",
-        "symplify/easy-coding-standard": "^11.1",
-        "symplify/package-builder": "^11.2",
-        "symplify/phpstan-extensions": "^11.1",
-        "symplify/symplify-kernel": "^11.2",
-        "tomasvotruba/unused-public": "^0.0.34"
+        "phpstan/extension-installer": "^1.3",
+        "phpunit/phpunit": "^10.4",
+        "rector/rector": "^0.18",
+        "symplify/easy-ci": "^11.3",
+        "symplify/easy-coding-standard": "^12.0",
+        "symplify/package-builder": "^11.3",
+        "symplify/phpstan-extensions": "^11.4",
+        "symplify/symplify-kernel": "^11.1",
+        "tomasvotruba/unused-public": "^0.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,6 @@
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    verbose="true"
->
-    <testsuite name="all">
-        <directory>tests</directory>
-    </testsuite>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <testsuite name="all">
+    <directory>tests</directory>
+  </testsuite>
 </phpunit>

--- a/src/DependencyInjection/DefinitionFinder.php
+++ b/src/DependencyInjection/DefinitionFinder.php
@@ -39,7 +39,7 @@ final class DefinitionFinder
     public function getByType(ContainerBuilder $containerBuilder, string $type): Definition
     {
         $definition = $this->getByTypeIfExists($containerBuilder, $type);
-        if ($definition !== null) {
+        if ($definition instanceof Definition) {
             return $definition;
         }
 

--- a/src/Skipper/ParameterSkipper.php
+++ b/src/Skipper/ParameterSkipper.php
@@ -89,11 +89,11 @@ final class ParameterSkipper
             return false;
         }
 
-        $reflectionParameterType = $reflectionParameter->getType();
-        if (! $reflectionParameterType instanceof ReflectionNamedType) {
+        $reflectionType = $reflectionParameter->getType();
+        if (! $reflectionType instanceof ReflectionNamedType) {
             return false;
         }
 
-        return $reflectionParameterType->getName() === 'array';
+        return $reflectionType->getName() === 'array';
     }
 }

--- a/tests/DependencyInjection/CompilerPass/Source/ArrayShapeCollector.php
+++ b/tests/DependencyInjection/CompilerPass/Source/ArrayShapeCollector.php
@@ -44,5 +44,4 @@ final class ArrayShapeCollector
     {
         return $this->secondCollected;
     }
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Collected/FirstServiceOfFirstCollected.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Collected/FirstServiceOfFirstCollected.php
@@ -8,5 +8,4 @@ use Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass\Sourc
 
 final class FirstServiceOfFirstCollected implements FirstCollectedInterface
 {
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Collected/FirstServiceOfSecondCollected.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Collected/FirstServiceOfSecondCollected.php
@@ -8,5 +8,4 @@ use Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass\Sourc
 
 final class FirstServiceOfSecondCollected implements SecondCollectedInterface
 {
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Collected/SecondServiceOfFirstCollected.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Collected/SecondServiceOfFirstCollected.php
@@ -8,5 +8,4 @@ use Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass\Sourc
 
 final class SecondServiceOfFirstCollected implements FirstCollectedInterface
 {
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Collected/SecondServiceOfSecondCollected.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Collected/SecondServiceOfSecondCollected.php
@@ -8,5 +8,4 @@ use Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass\Sourc
 
 final class SecondServiceOfSecondCollected implements SecondCollectedInterface
 {
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Contract/FirstCollectedInterface.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Contract/FirstCollectedInterface.php
@@ -6,5 +6,4 @@ namespace Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass
 
 interface FirstCollectedInterface
 {
-
 }

--- a/tests/DependencyInjection/CompilerPass/Source/Contract/SecondCollectedInterface.php
+++ b/tests/DependencyInjection/CompilerPass/Source/Contract/SecondCollectedInterface.php
@@ -6,5 +6,4 @@ namespace Symplify\AutowireArrayParameter\Tests\DependencyInjection\CompilerPass
 
 interface SecondCollectedInterface
 {
-
 }

--- a/tests/DocBlock/ParamTypeDocBlockResolverTest.php
+++ b/tests/DocBlock/ParamTypeDocBlockResolverTest.php
@@ -26,7 +26,7 @@ final class ParamTypeDocBlockResolverTest extends TestCase
         $this->assertSame($expectedType, $resolvedType);
     }
 
-    public function provideData(): Iterator
+    public static function provideData(): Iterator
     {
         yield ['/** @param Type[] $name */', 'name', 'Type'];
         yield ['/** @param array<Type> $name */', 'name', 'Type'];
@@ -45,7 +45,7 @@ final class ParamTypeDocBlockResolverTest extends TestCase
     /**
      * @return Iterator<string[]>
      */
-    public function provideDataMissmatchName(): Iterator
+    public static function provideDataMissmatchName(): Iterator
     {
         yield ['/** @param Type[] $name */', '___not'];
     }


### PR DESCRIPTION
Hi,

I updated required packages as I dont know the reason behind it but mainly the `symfony/dependency-injection` was stucked at version `6.1.x` so this package in latest versions could not be installed with latest symfony versions like `6.2` and `6.3`. Also I updated rest of packages mainly dev ones to latest versions and I allowed this package to be used with `nette/utils` version `4.x` it uses just some String helper fuctions so its fine to use it in both versions as I saw that already in others packages of yours.

I updated `PHPUnit` to `10.4` and it's config.
There are some cosmetics changes done by `rector` and `ecs` because of those new versions.

Hope this will help :)